### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 |---| --- |
 | Version | ![](https://badgen.net/packagist/v/markette/gopay-simple) |
 | PHP | ![](https://badgen.net/packagist/php/markette/gopay-simple) |
-| License | ![](https://badgen.net/github/license/markette/gopay-simple) |
+| License | ![](https://badgen.net/github/license/contributte/gopay-simple) |
 
 ## Documentation
 
@@ -136,7 +136,7 @@ Example of [GopayService](https://github.com/Markette/GopaySimple/blob/master/ex
 
 ## Development
 
-This package was maintain by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
@@ -145,4 +145,4 @@ This package was maintain by these authors.
 -----
 
 Consider to [support](https://contributte.org/partners.html) **contributte** development team.
-Also thank you for being used this package.
+Also thank you for using this package.


### PR DESCRIPTION
## Summary

This PR fixes minor issues in the README to fully conform to the archive template:

- Fixed license badge to use `contributte/gopay-simple` instead of `markette/gopay-simple`
- Fixed grammar: "was maintain" → "was maintained"
- Fixed grammar: "for being used this package" → "for using this package"

## Changes

- License badge now correctly references the contributte organization
- Development section text is grammatically correct
- Footer text is grammatically correct

All changes align with the archive repository template in `.ai/archive-repo.md`.